### PR TITLE
dev1: (refactor) remover posição absoluta do conteúdo do navbar

### DIFF
--- a/ac/globalheader/navbar/1/pt_BR/styles/globalnavbar.css
+++ b/ac/globalheader/navbar/1/pt_BR/styles/globalnavbar.css
@@ -236,7 +236,6 @@
   #globalnavbar .globalnavbar-content {
     display: flex;
     padding: 0;
-    position: absolute;
     top: 0;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
This pull request contains a small change to the `globalnavbar.css` stylesheet. The `position: absolute;` property was removed from the `.globalnavbar-content` class.