### PR TITLE
refactor: refactor navbar in website fixing issue #476

### DIFF
--- a/404.html
+++ b/404.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/404.html
+++ b/404.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/ac/globalheader/header/1/pt_BR/styles/header.css
+++ b/ac/globalheader/header/1/pt_BR/styles/header.css
@@ -104,6 +104,10 @@ body {
   height: 100%;
   width: auto;
 }
+                                               
+#globalheader svg[fill="none"] {
+  fill: black !important;
+}
 
 #globalheader button {
   background: none;

--- a/ac/globalheader/navbar/1/pt_BR/scripts/globalnavbar.build.js
+++ b/ac/globalheader/navbar/1/pt_BR/scripts/globalnavbar.build.js
@@ -136,3 +136,39 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 });
+
+// Adicionar esta função para monitorar mudanças de tela
+function handleResize() {
+  const navbar = document.getElementById("globalnavbar");
+
+  // Se a tela for >= 834px, remover a classe globalnavbar-open
+  if (window.innerWidth >= 834) {
+    if (navbar && navbar.classList.contains("globalnavbar-open")) {
+      navbar.classList.remove("globalnavbar-open");
+
+      // Resetar estado do menu se necessário
+      const curtain = document.getElementById("globalnavbar-curtain");
+      if (curtain) {
+        curtain.classList.remove("globalnavbar-curtain-visible");
+      }
+
+      // Resetar botão do menu
+      const menuButton = document.getElementById("globalnavbar-menutrigger-button");
+      if (menuButton) {
+        menuButton.setAttribute("aria-expanded", "false");
+        menuButton.setAttribute("aria-label", "Abrir menu principal");
+      }
+
+      // Resetar variável de estado se existir
+      if (typeof isMenuOpen !== 'undefined') {
+        isMenuOpen = false;
+      }
+    }
+  }
+}
+
+// Adicionar event listener para resize
+window.addEventListener("resize", handleResize);
+
+// Executar uma vez no carregamento
+document.addEventListener("DOMContentLoaded", handleResize);

--- a/ac/globalheader/navbar/2/pt_BR/styles/globalnavbar.css
+++ b/ac/globalheader/navbar/2/pt_BR/styles/globalnavbar.css
@@ -416,6 +416,11 @@
   }
 }
 
+#globalnavbar .globalnavbar-list .globalnavbar-submenu .globalnavbar-submenu-content h2[class="globalnavbar-submenu-header"] {
+  border-bottom: 1px solid #dee2e6;
+  padding-bottom: 0.5rem;
+}
+
 #globalnavbar .globalnavbar-list .globalnavbar-submenu .globalnavbar-submenu-content .globalnavbar-submenu-header {
   color: var(--r-globalnavbar-submenu-header-color, rgb(110, 110, 115));
   display: block;

--- a/apps/ira/index.html
+++ b/apps/ira/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/apps/ira/index.html
+++ b/apps/ira/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/boasvindas/index.html
+++ b/boasvindas/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/boasvindas/index.html
+++ b/boasvindas/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/book/CIC0007/conteudo/01/introducao.html
+++ b/book/CIC0007/conteudo/01/introducao.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/CIC0007/conteudo/02/conclusao.html
+++ b/book/CIC0007/conteudo/02/conclusao.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/CIC0007/conteudo/02/metodologia.html
+++ b/book/CIC0007/conteudo/02/metodologia.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/CIC0007/conteudo/03/apendice.html
+++ b/book/CIC0007/conteudo/03/apendice.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/CIC0007/conteudo/03/references.html
+++ b/book/CIC0007/conteudo/03/references.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/CIC0007/index.html
+++ b/book/CIC0007/index.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/index.html
+++ b/book/EST0033/index.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/postextuais/apendice/ementa.html
+++ b/book/EST0033/postextuais/apendice/ementa.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/postextuais/apendice/formulas/cap1.html
+++ b/book/EST0033/postextuais/apendice/formulas/cap1.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/postextuais/apendice/formulas/formulas.html
+++ b/book/EST0033/postextuais/apendice/formulas/formulas.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/postextuais/bibliografia/references.html
+++ b/book/EST0033/postextuais/bibliografia/references.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/pretextuais/sumario.html
+++ b/book/EST0033/pretextuais/sumario.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/textuais/unid1/brasil.html
+++ b/book/EST0033/textuais/unid1/brasil.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/textuais/unid1/introd.html
+++ b/book/EST0033/textuais/unid1/introd.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/textuais/unid2/introd.html
+++ b/book/EST0033/textuais/unid2/introd.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/textuais/unid3/introd.html
+++ b/book/EST0033/textuais/unid3/introd.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/EST0033/textuais/unid4/introd.html
+++ b/book/EST0033/textuais/unid4/introd.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/MAT0075/exercicios/topico1.html
+++ b/book/MAT0075/exercicios/topico1.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/MAT0075/index.html
+++ b/book/MAT0075/index.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/MAT0075/postextuais/references.html
+++ b/book/MAT0075/postextuais/references.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/MAT0075/textuais/topico1.html
+++ b/book/MAT0075/textuais/topico1.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/TAS0000/index.html
+++ b/book/TAS0000/index.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/TAS0000/postextuais/references.html
+++ b/book/TAS0000/postextuais/references.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/TAS0000/pretextuais/fontsdados.html
+++ b/book/TAS0000/pretextuais/fontsdados.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/TAS0000/pretextuais/statinBrazil.html
+++ b/book/TAS0000/pretextuais/statinBrazil.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/TAS0000/pretextuais/whatsstatistc.html
+++ b/book/TAS0000/pretextuais/whatsstatistc.html
@@ -210,7 +210,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -228,7 +228,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -316,7 +316,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -398,7 +398,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -525,7 +525,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -620,7 +620,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -715,7 +715,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -810,7 +810,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -909,7 +909,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1012,7 +1012,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1107,7 +1107,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1347,9 +1347,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/book/index.html
+++ b/book/index.html
@@ -212,7 +212,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -230,7 +230,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -318,7 +318,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -400,7 +400,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -527,7 +527,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -622,7 +622,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -717,7 +717,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -812,7 +812,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -911,7 +911,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
@@ -1014,7 +1014,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1109,7 +1109,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1349,9 +1349,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/errors/404/index.html
+++ b/errors/404/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/errors/404/index.html
+++ b/errors/404/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0000/index.html
+++ b/newsroom/archive/2025/07/0000/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0000/index.html
+++ b/newsroom/archive/2025/07/0000/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0001/index.html
+++ b/newsroom/archive/2025/07/0001/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0001/index.html
+++ b/newsroom/archive/2025/07/0001/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0002/index.html
+++ b/newsroom/archive/2025/07/0002/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0002/index.html
+++ b/newsroom/archive/2025/07/0002/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0003/index.html
+++ b/newsroom/archive/2025/07/0003/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0003/index.html
+++ b/newsroom/archive/2025/07/0003/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0004/index.html
+++ b/newsroom/archive/2025/07/0004/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0004/index.html
+++ b/newsroom/archive/2025/07/0004/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/archive/2025/07/0005/index.html
+++ b/newsroom/archive/2025/07/0005/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/archive/2025/07/0005/index.html
+++ b/newsroom/archive/2025/07/0005/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/newsroom/index.html
+++ b/newsroom/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/docente/cesargabrielphd/index.html
+++ b/pages/docente/cesargabrielphd/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/docente/cesargabrielphd/index.html
+++ b/pages/docente/cesargabrielphd/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/docente/index.html
+++ b/pages/docente/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/docente/index.html
+++ b/pages/docente/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/leadership/cesargabriel/index.html
+++ b/pages/leadership/cesargabriel/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/leadership/cesargabriel/index.html
+++ b/pages/leadership/cesargabriel/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/leadership/index.html
+++ b/pages/leadership/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/leadership/index.html
+++ b/pages/leadership/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/legal/index.html
+++ b/pages/legal/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/legal/index.html
+++ b/pages/legal/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/legal/privacy/index.html
+++ b/pages/legal/privacy/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/legal/privacy/index.html
+++ b/pages/legal/privacy/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">

--- a/pages/legal/terms/index.html
+++ b/pages/legal/terms/index.html
@@ -106,7 +106,7 @@
 </button>
 </div>
 <ul class="globalnavbar-list" id="globalnavbar-list">
-<li class="globalnavbar-item" id="globalnavbar-item-estatistica">
+<li class="globalnavbar-item" id="globalnavbar-item-estatistica" style="display: none">
 <a class="globalnavbar-item-link globalnavbar-link-estatistica" href="/">
 <span class="globalnavbar-link-estatistica-container">
 <span class="globalnavbar-link-text globalnavbar-link-text-estatistica">Estatística</span>
@@ -124,7 +124,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-boasvindas">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Boas Vindas</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="/registro-academico/">Registro Acadêmico</a>
@@ -212,7 +212,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-documentos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Documentos</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="https://www.unb.br/images/Documentos/Estatuto_e_Regimento_Geral_UnB.pdf" target="_blank">Estatuto e
@@ -294,7 +294,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-Departamento">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Departamento</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">História</a>
@@ -421,7 +421,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-graduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Descrição</a>
@@ -516,7 +516,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-posgraduacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Pós-Graduação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Doutorado em Estatística</a>
@@ -611,7 +611,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-educacao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Educação</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Moodle</a>
@@ -706,7 +706,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-extensao">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Extensão</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Monitoria</a>
@@ -908,7 +908,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-noticias">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">Notícias</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Últimas Notícias</a>
@@ -1003,7 +1003,7 @@
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-unb">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">
 <div class="globalnavbar-submenu-group globalnavbar-submenu-group-elevated">
-<h2 class="globalnavbar-submenu-header">Destaque</h2>
+<h2 class="globalnavbar-submenu-header">UnB</h2>
 <ul class="globalnavbar-submenu-list">
 <li class="globalnavbar-submenu-list-item-elevated">
 <a class="globalnavbar-submenu-link" href="#">Portal da UnB</a>
@@ -1243,9 +1243,8 @@
 </button>
 </div>
 </div>
-<div class="globalnavbar-curtain" id="globalnavbar-curtain" style="display: none;">
-     
-  </div>
+<div class="globalnavbar-curtain" id="globalnavbar-curtain">
+</div>
 </nav><section id="globalribbon">
 <div id="globalribbon-content">
 <div class="globalribbon-item">

--- a/pages/legal/terms/index.html
+++ b/pages/legal/terms/index.html
@@ -805,7 +805,7 @@
 </li>
 <li class="globalnavbar-item" id="globalnavbar-item-eventos">
 <a class="globalnavbar-item-link globalnavbar-link-eventos" href="/eventos/" target="_self">
-<span class="globalnavbar-link-text">UnB</span>
+<span class="globalnavbar-link-text">Eventos</span>
 </a>
 <div class="globalnavbar-submenu globalnavbar-flyout" id="globalnavbar-submenu-link-eventos">
 <div class="globalnavbar-submenu-content globalnavbar-flyout-content">


### PR DESCRIPTION
issues: corrigir "Destaque" dos `h2.*group-header ` da navbar Fixes #476

This pull request updates the navigation bar in several HTML files to improve clarity and organization. The most important changes include hiding the "Estatística" menu item, renaming submenu headers for better context, and cleaning up the navigation curtain markup.

Navigation bar visibility and structure:

* The "Estatística" menu item in the navigation bar is now hidden by default by adding `style="display: none"` to its list item in `404.html`, `apps/ira/index.html`, and `boasvindas/index.html`. [[1]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL109-R109) [[2]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L109-R109) [[3]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L109-R109)

Navigation submenu header improvements:

* Multiple submenu headers previously labeled as "Destaque" have been renamed to more descriptive titles such as "Boas Vindas", "Documentos", "Departamento", "Graduação", "Pós-Graduação", "Educação", "Extensão", "Notícias", and "UnB" across the navigation in all three files. This enhances user understanding and navigation clarity. [[1]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL127-R127) [[2]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL215-R215) [[3]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL297-R297) [[4]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL424-R424) [[5]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL519-R519) [[6]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL614-R614) [[7]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL709-R709) [[8]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL911-R911) [[9]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL1006-R1006) [[10]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L127-R127) [[11]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L215-R215) [[12]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L297-R297) [[13]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L424-R424) [[14]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L519-R519) [[15]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L614-R614) [[16]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L709-R709) [[17]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L911-R911) [[18]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L1006-R1006) [[19]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L127-R127) [[20]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L215-R215) [[21]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L297-R297) [[22]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L424-R424) [[23]](diffhunk://#diff-20c88f010be77c01d52b375b88588aae5e443846f4ba32b5ca331c9d9ed1fb47L519-R519)

Navigation curtain markup cleanup:

* The `globalnavbar-curtain` element no longer uses `style="display: none;"` and has had unnecessary whitespace removed in `404.html` and `apps/ira/index.html`, likely to improve how overlays are handled in the navigation. [[1]](diffhunk://#diff-128cc35baaf40bac8ae4d2932ca6e009311e8279f03f258e9cc83966f1d5b32eL1246-R1246) [[2]](diffhunk://#diff-52194c7322c22af477e71b159f4471357405428a7658673b48e74c542b6e4f12L1246-R1246)