### PR TITLE
ci: add Git credentials configuration for private submodules in workflow

### DIFF
--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -27,13 +27,10 @@ jobs:
     environment:
       name: ENVIRONMENT
     steps:
-      - name: Configura credenciais do Git
-        working-directory: estatistica
+      
+      - name: Configura credenciais do Git para submódulos privados
         run: |
-          git config --global url."https://${{ env.TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-          git remote set-url origin https://${{ env.TOKEN }}:x-oauth-basic@github.com/${{ github.repository }}.git
-          git config user.name "${{ env.USERNAME }}"
-          git config user.email "${{ env.USEREMAIL }}@users.noreply.github.com"
+          git config --global url."https://${{ secrets.GITHUB_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
           
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -27,6 +27,14 @@ jobs:
     environment:
       name: ENVIRONMENT
     steps:
+      - name: Configura credenciais do Git
+        working-directory: estatistica
+        run: |
+          git config --global url."https://${{ env.TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+          git remote set-url origin https://${{ env.TOKEN }}:x-oauth-basic@github.com/${{ github.repository }}.git
+          git config user.name "${{ env.USERNAME }}"
+          git config user.email "${{ env.USEREMAIL }}@users.noreply.github.com"
+          
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Introduce a configuration step to set Git credentials for accessing private submodules in the workflow. This enhances the ability to work with private repositories seamlessly.