### PR TITLE
dev1: standardization process in the CI workflow and adjusts VSCode editor settings

### DIFF
--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -168,9 +168,7 @@ jobs:
         if: steps.books-list.outputs.has_books == 'true'
         run: |
           echo "🎨 Aplicando padronização HTML..."
-          python ./backend/actions/run/site_html_manager.py --only-head --dynamic-head --path ./book/
-          python ./backend/actions/run/site_html_manager.py --only-header --path ./book/
-          python ./backend/actions/run/site_html_manager.py --only-footer --path ./book/
+          python ./backend/actions/run/site_html_manager.py --update-all --path ./book/
           echo "✅ Padronização concluída!"
 
       - name: Commit e criar Pull Request

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,20 +71,20 @@
   "editor.hideCursorInOverviewRuler": true,
   "editor.scrollbar.vertical": "hidden",
 
-  // ✅ DESATIVAR ITENS ENFATIZADOS
-  "editor.occurrencesHighlight": "off", // Desativa destaque de ocorrências
-  "editor.selectionHighlight": true, // Desativa destaque de seleções similares
-  "editor.renderLineHighlight": "none", // Desativa destaque da linha atual (sobrescreve "gutter")
-  "editor.matchBrackets": "never", // Desativa destaque de parênteses correspondentes
-  "editor.guides.bracketPairs": false, // Desativa linhas guia de pares de colchetes
-  "editor.guides.bracketPairsHorizontal": false, // Desativa guias horizontais de colchetes
-  "editor.guides.highlightActiveBracketPair": false, // Desativa destaque do par ativo
-  "editor.guides.indentation": false, // Desativa linhas de indentação
-  "editor.guides.highlightActiveIndentation": false, // Desativa destaque da indentação ativa
-  "editor.bracketPairColorization.enabled": false, // Desativa colorização de pares de colchetes
-  "editor.linkedEditing": false, // Desativa edição vinculada de tags HTML
-  "editor.foldingHighlight": false, // Desativa destaque de regiões dobráveis
-  "editor.showFoldingControls": "never", // Remove controles de dobra de código
+  // // ✅ DESATIVAR ITENS ENFATIZADOS
+  // "editor.occurrencesHighlight": "off", // Desativa destaque de ocorrências
+  // "editor.selectionHighlight": true, // Desativa destaque de seleções similares
+  // "editor.renderLineHighlight": "none", // Desativa destaque da linha atual (sobrescreve "gutter")
+  // "editor.matchBrackets": "never", // Desativa destaque de parênteses correspondentes
+  // "editor.guides.bracketPairs": false, // Desativa linhas guia de pares de colchetes
+  // "editor.guides.bracketPairsHorizontal": false, // Desativa guias horizontais de colchetes
+  // "editor.guides.highlightActiveBracketPair": false, // Desativa destaque do par ativo
+  // "editor.guides.indentation": false, // Desativa linhas de indentação
+  // "editor.guides.highlightActiveIndentation": false, // Desativa destaque da indentação ativa
+  // "editor.bracketPairColorization.enabled": false, // Desativa colorização de pares de colchetes
+  // "editor.linkedEditing": false, // Desativa edição vinculada de tags HTML
+  // "editor.foldingHighlight": false, // Desativa destaque de regiões dobráveis
+  // "editor.showFoldingControls": "never", // Remove controles de dobra de código
 
   "editor.tokenColorCustomizations": {
     "textMateRules": [


### PR DESCRIPTION
This pull request streamlines the HTML standardization process in the CI workflow and adjusts VSCode editor settings by commenting out previously enforced visual de-emphasis options. The main changes focus on improving automation and making editor configuration less restrictive.

**CI Workflow Improvements:**

* Replaced multiple specific HTML standardization commands with a single `--update-all` command in `site_html_manager.py` for the `/book` directory, simplifying and consolidating the automation process.

**Editor Configuration Adjustments:**

* Commented out various settings in `.vscode/settings.json` that previously disabled or altered editor highlighting and guides, making these visual features available for developers to enable as needed.